### PR TITLE
Ignore Makefile, swp files

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,10 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees \
+		  --ignore "*.swp" \
+		  --ignore "Makefile" \
+		  $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 


### PR DESCRIPTION
During the autobuild process, add ignore parameters, such that the
autobuild does not build non-doc files.

Signed-off-by: Peter Schwarz peter.schwarz@bicycle.io
