### PR TITLE
Remove ssh keygen instructions for Windows 10

### DIFF
--- a/docs/setup_win10.md
+++ b/docs/setup_win10.md
@@ -80,31 +80,6 @@ If you do not see this link on your dashboard, you can download the toolbelt fro
 
 You will download an .exe file. Run this executable to install the Heroku Toolbelt and follow all prompts from the installation wizard.
 
-Before you can use Heroku, you will have to set up SSH, the way your computer communicates with Heroku.
-
-First, look up what your user directory is. You can find it by running `echo %USERPROFILE%`. Then, run these commands:
-
-```
-mkdir "%USERPROFILE%\.ssh"
-```
-
-Then, if you have 32-bit Windows, run this command:
-
-```
-"C:\Program Files\Git\bin\ssh-keygen.exe"
-```
-
-If you have 64-bit Windows, run this command instead:
-
-```
-"C:\Program Files (x86)\Git\bin\ssh-keygen.exe"
-```
-
-The quotes are necessary on the `ssh-keygen.exe` command. When you run `ssh-keygen.exe`, you will need to type the name of your user directory - everything from "C:\" onward - plus `\.ssh\id_rsa` when it asks you where to save the key. Be careful to type everything exactly. When it asks to 'Enter passphrase' just hit Enter, then Enter again. *Look at the following example:*
-
-![ssh-keygen](img/win7/ssh-keygen.png)
-
-After that, close the command prompt, open it back up, and run the command `heroku login`. You will be prompted for your email and password on Heroku. If you enter them and the command ends successfully, congratulations!
 
 ## Testing your setup
 


### PR DESCRIPTION
ssy keygen instructions were removed for windows 10 setup.  I didn't remove from the windows 7 or windows 8 setup because I didn't have a way to test those systems and the risk of needing the instructions and not having them seemed worse than the risk of having the instructions and not needing them.