### PR TITLE
Remove the dependency on ring-mock.

### DIFF
--- a/docs/track1/Page_6_Push_to_live.md
+++ b/docs/track1/Page_6_Push_to_live.md
@@ -54,8 +54,7 @@ Our new `project.clj` should look like:
   :main chatter.handler
   :profiles
   {:dev
-   {:dependencies [[javax.servlet/servlet-api "2.5"]
-                   [ring-mock "0.3.0"]]}
+   {:dependencies [[javax.servlet/servlet-api "2.5"]]}
    :production
    {:ring
     {:open-browser? false, :stacktraces? false, :auto-reload? false}


### PR DESCRIPTION
For some reason we are having trouble pulling down the dependency for `ring-mock 0.3.0`. I'm removing it for now because its unneeded.